### PR TITLE
Multiple Tile Removal, Full asset deletion from tile, and more

### DIFF
--- a/core/src/com/isomapmaker/game/controls/AssetPlacer.java
+++ b/core/src/com/isomapmaker/game/controls/AssetPlacer.java
@@ -15,10 +15,12 @@ import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
 import com.isomapmaker.game.controls.AtlasBrowser.AtlasBrowser;
 import com.isomapmaker.game.controls.commands.BoxCommand;
+import com.isomapmaker.game.controls.commands.BoxEraserCommand;
 import com.isomapmaker.game.controls.commands.BucketCommand;
 import com.isomapmaker.game.controls.commands.CircleCommand;
 import com.isomapmaker.game.controls.commands.Command;
 import com.isomapmaker.game.controls.commands.Commander;
+import com.isomapmaker.game.controls.commands.FullEraser;
 import com.isomapmaker.game.controls.commands.LineCommand;
 import com.isomapmaker.game.controls.commands.PencilCommand;
 import com.isomapmaker.game.controls.commands.PencilEraserCommand;
@@ -99,7 +101,10 @@ public class AssetPlacer implements InputProcessor {
         // TODO Auto-generated method stub
         if(controlModifier){
             switch(keycode){
-                
+                case Input.Keys.C: // full tile clear 
+                    FullEraser eraser = new FullEraser(tilePos, map);
+                    Commander.getInstance().run(eraser);
+                break;
             }
         }
         else{
@@ -183,8 +188,14 @@ public class AssetPlacer implements InputProcessor {
         //
         switch(this.paintState){
             case Box:
-                BoxCommand box = new BoxCommand(clickPos, endclick, ModeController.getInstance().getActiveAsset(), map);
-                Commander.getInstance().run(box);
+                Command c = null;
+                if(controlModifier){
+                    c = new BoxEraserCommand(clickPos, endclick, map);
+                }
+                else{
+                    c = new BoxCommand(clickPos, endclick, ModeController.getInstance().getActiveAsset(), map);
+                }
+                Commander.getInstance().run(c);
                 break;
             case Circle:
                 CircleCommand circ = new CircleCommand((int)clickPos.x, (int)clickPos.y, (int)clickPos.dst(endclick), ModeController.getInstance().getActiveAsset(), map);
@@ -422,6 +433,10 @@ public class AssetPlacer implements InputProcessor {
     @Override
     public boolean keyUp(int keycode) {
         // TODO Auto-generated method stub
+        if(keycode == Input.Keys.CONTROL_LEFT){
+            controlModifier = false;
+            return true;
+        }
         return false;
     }
 

--- a/core/src/com/isomapmaker/game/controls/commands/BoxEraserCommand.java
+++ b/core/src/com/isomapmaker/game/controls/commands/BoxEraserCommand.java
@@ -1,0 +1,36 @@
+package com.isomapmaker.game.controls.commands;
+
+import com.badlogic.gdx.math.Vector2;
+import com.isomapmaker.game.map.TileMaps.TileMap;
+
+public class BoxEraserCommand extends Command {
+
+    Vector2 start,end;
+    public BoxEraserCommand(Vector2 start, Vector2 end, TileMap map) {
+        super(map);
+        this.start = start;
+        this.end = end;
+
+        //TODO Auto-generated constructor stub
+    }
+
+    private void BoxErase(){
+        int lx = start.x < end.x ? (int) start.x : (int) end.x;
+        int ly = start.y < end.y ? (int) start.y : (int) end.y;
+        int dx = (int)Math.abs(start.x - end.x);
+        int dy = (int)Math.abs(start.y - end.y);
+
+        for(int x=lx; x<lx+dx+1; x++){
+            for(int y=ly; y<ly+dy+1; y++){
+                map.clearTile(x, y);
+            }
+        }
+
+    }
+
+    @Override
+    public void executeCommand() {
+        BoxErase();
+    }
+    
+}

--- a/core/src/com/isomapmaker/game/controls/commands/CommandStack.java
+++ b/core/src/com/isomapmaker/game/controls/commands/CommandStack.java
@@ -1,0 +1,33 @@
+package com.isomapmaker.game.controls.commands;
+
+import java.util.Vector;
+
+public class CommandStack {
+    int max;
+    Vector<Command> stack;
+    public CommandStack(int maxSize){
+        max = maxSize;
+        stack = new Vector<Command>(max);
+    }
+
+    public Command pop(){
+        if(stack.isEmpty()) return null;
+        Command c = stack.remove(stack.size()-1);
+        return c;
+    }
+
+    public void push(Command c){
+        if(stack.size() == max){
+            popOldest();
+        }
+        stack.add(c);
+    }
+
+    /**
+     * remove the oldest item in the stack
+     */
+    public void popOldest(){
+        if(stack.isEmpty()) return;
+        stack.remove(0);
+    }
+}

--- a/core/src/com/isomapmaker/game/controls/commands/Commander.java
+++ b/core/src/com/isomapmaker/game/controls/commands/Commander.java
@@ -7,7 +7,7 @@ import java.util.Vector;
  */
 public class Commander {
     private static Commander instance; // The instance we return 
-    private Vector<Command> editStack, undoStack; // stacks to contain recently executed or undone commands
+    private CommandStack editStack, undoStack; // stacks to contain recently executed or undone commands
 
     // Ensure singleton (not considering multithread access)
     public static Commander getInstance(){
@@ -20,17 +20,10 @@ public class Commander {
 
     // Private constructor to ensure singleton status
     private Commander(){
-        editStack = new Vector<Command>();
-        undoStack = new Vector<Command>();
+        editStack = new CommandStack(10);
+        undoStack = new CommandStack(10);
     }
 
-    // Pop the last command if there is one 
-    private Command pop(Vector<Command> stack){
-        if(stack.size() < 1) return null;
-        Command com = stack.get(stack.size()-1);
-        stack.remove(stack.size()-1);
-        return com;
-    }
 
     /**
      * Execute the specified command and attach it to our command history 
@@ -38,16 +31,16 @@ public class Commander {
      */
     public void run(Command com){
         com.execute();
-        editStack.add(com);
+        editStack.push(com);
     }
 
     /**
      * Undo the most recently issued command and add it to our undo history
      */
     public void undo(){
-        Command com = pop(editStack);
+        Command com = editStack.pop();
         if(com == null) return;
-        undoStack.add(com);
+        undoStack.push(com);
         com.undo();
     }
 
@@ -55,7 +48,7 @@ public class Commander {
      * Redo our last undo (This stuff gets kind of funky with saving the map if issued to fast)
      */
     public void redo(){
-        Command com = pop(undoStack);
+        Command com = undoStack.pop();
         if(com == null) return;
         run(com);
     }

--- a/core/src/com/isomapmaker/game/controls/commands/FullEraser.java
+++ b/core/src/com/isomapmaker/game/controls/commands/FullEraser.java
@@ -1,0 +1,23 @@
+package com.isomapmaker.game.controls.commands;
+
+import com.badlogic.gdx.math.Vector2;
+import com.isomapmaker.game.map.TileMaps.TileMap;
+
+public class FullEraser extends Command {
+    Vector2 tilePos;
+    public FullEraser(Vector2 tilePos, TileMap map){
+        super(map);
+        this.tilePos = tilePos;
+    }
+
+    private boolean FullErase(){
+        this.map.clearTile((int)tilePos.x, (int)tilePos.y);
+        return true;
+    }
+
+    @Override
+    public void executeCommand() {
+        FullErase();
+    }
+    
+}

--- a/core/src/com/isomapmaker/game/map/Assets/Tile.java
+++ b/core/src/com/isomapmaker/game/map/Assets/Tile.java
@@ -18,7 +18,11 @@ public class Tile {
     
 
     public Tile(Tile copy){
-        this.walls = copy.walls;
+        this.walls = new HashMap<WallQuadrant, Wall>(4);
+        this.walls.put(WallQuadrant.bottom, copy.getWall(WallQuadrant.bottom));
+        this.walls.put(WallQuadrant.top, copy.getWall(WallQuadrant.top));
+        this.walls.put(WallQuadrant.left, copy.getWall(WallQuadrant.left));
+        this.walls.put(WallQuadrant.right, copy.getWall(WallQuadrant.right));
         this.floor = copy.floor;
         this.object = copy.object;
     }

--- a/core/src/com/isomapmaker/game/map/TileMaps/TileMap.java
+++ b/core/src/com/isomapmaker/game/map/TileMaps/TileMap.java
@@ -100,7 +100,7 @@ public class TileMap {
      */
     public void setFloor(int x, int y, Asset f){
         if (!inBounds(x, y)) return;
-        //if (map[x][y] == null) map[x][y]= new Tile();
+        if (map[x][y] == null) map[x][y]= new Tile();
         map[x][y].setFloor(f);
 
     }
@@ -112,7 +112,7 @@ public class TileMap {
      * @return
      */
     public Floor getFloor(int x, int y){
-        if (!inBounds(x, y)) return null;
+        if (!hasTile(x, y)) return null;
         return map[x][y].getFloor();
     }
 /*
@@ -132,7 +132,7 @@ public class TileMap {
      */
     public void setWall(int x, int y, WallQuadrant quad, Asset w){
         if(!inBounds(x, y)) return;
-        //if (map[x][y] == null) map[x][y] = new Tile();
+        if (map[x][y] == null) map[x][y] = new Tile();
         map[x][y].setWall(w, quad);
         
     }
@@ -181,8 +181,15 @@ public class TileMap {
 
 public void setObject(int x, int y, Asset o){
     if(!inBounds(x, y)) return;
-    //if(map[x][y] == null) map[x][y] = new Tile();
+    if(map[x][y] == null) map[x][y] = new Tile();
     map[x][y].setObject(o);
+}
+
+
+
+public void clearTile(int x, int y){
+    if(!hasTile(x, y)) return;
+    map[x][y].clearTile();
 }
 
 /*
@@ -225,6 +232,7 @@ public void setObject(int x, int y, Asset o){
      */
     public String getTileString(int x, int y){
         if(!inBounds(x, y)) return "";
+        if(map[x][y] == null) return "";
         return map[x][y].toString2();
     }
 
@@ -270,6 +278,7 @@ public void setObject(int x, int y, Asset o){
             String[] tiles = inMap[line].split(",", size);
             if(inMap[line].equals("=")) continue;
             for(int tile=0; tile<tiles.length && tile < size; tile++){ // ensure we only place tiles that would fit in size
+                if(map[line][tile] == null) map[line][tile] = new Tile();
                 map[line][tile].parseString(tiles[tile]);
             }
         } 
@@ -283,8 +292,7 @@ public void setObject(int x, int y, Asset o){
     public void reloadMap(){
         for(int i=0; i< size; i++){
             for(int j=0; j<size; j++){
-                if(map[i][j] == null) map[i][j] = new Tile();
-                else map[i][j].clearTile();
+                map[i][j] = null;
             }
         }
     }

--- a/core/src/com/isomapmaker/game/util/MapCopy.java
+++ b/core/src/com/isomapmaker/game/util/MapCopy.java
@@ -14,6 +14,7 @@ public class MapCopy {
         for(int i=0; i< original.length; i++){
             copy[i] = new Tile[original[i].length];
             for(int j=0; j<original[i].length; j++){
+                if(original[i][j] == null) continue; 
                 copy[i][j] = new Tile(original[i][j]);
             }
         }


### PR DESCRIPTION
**Multiple Tiles / Full Asset**
- Control now enables a `controlModifier` which applies to the eraser and box tools as of right now 
- with the `controlModifier` enabled eraser will fully delete all assets on the tile (walls, floors, and objects)
- the box tool will remove all elements bounded within the box 

**Sparse Array** 
- Tile map now is fully initialized to null instead of tiles
- This reduces overhead of memory and was basically needed for the commands to not break the game

**Command Stack**
- I made a command stack class to restrict the size of our undo / redo history

*now I know not to intialize a bunch of objects for no reason lol*
